### PR TITLE
limit to 771 files permissions

### DIFF
--- a/.build-package-script.sh
+++ b/.build-package-script.sh
@@ -263,7 +263,7 @@ post_install_script=$(mktemp $MKTEMP_POSTSCRIPT_CONF)
 echo "#!/bin/sh
 mkdir -p /etc/kong
 mv /usr/local/lib/luarocks/rocks/kong/$rockspec_version/kong.conf.default /etc/kong/kong.conf.default
-chmod -R 777 /usr/local/kong/
+chmod -R 771 /usr/local/kong/
 " > $post_install_script
 
 ##############################################################


### PR DESCRIPTION
Files and directories under `/usr/local/kong` are in `777` mode which cause security issues.
Limiting to `771` should be fine.